### PR TITLE
Fix docs to always show full options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ examples:
   ```
 - Create multiple images using predefined styles
   ```bash
-  python pg.py multistyle -i idea.txt -s "style1,style2" -o out.png
+  python pg.py multistyle -i idea.txt -s "style1,style2" --output_file out.png
   ```
 - Generate a picture in a single style
   ```bash
-  python pg.py picbystyle -i idea.txt -p "extra details" -s style1 -o result.png
+  python pg.py picbystyle -i idea.txt -p "extra details" -s style1 --output_file result.png
   ```
 
 More detailed instructions, including configuration and available styles, can be

--- a/docs/CREATING_PICTURES.md
+++ b/docs/CREATING_PICTURES.md
@@ -39,7 +39,7 @@ API. It assumes you already have Python 3 installed and an OpenAI API key.
    Assuming you have an idea prompt saved in `idea.txt`, generate an image
    using one of the styles defined in `support/styles.json`:
    ```bash
-   python pg.py picbystyle -i idea.txt -p "add flying cars" -s Retro_80s -o out.png
+   python pg.py picbystyle -i idea.txt -p "add flying cars" -s Retro_80s --output_file out.png
    ```
    The command combines the text in `idea.txt`, any additional prompt text
    ("add flying cars" in the example) and the `Retro_80s` style to create the
@@ -53,11 +53,11 @@ API. It assumes you already have Python 3 installed and an OpenAI API key.
    tool pick random ones for you:
    ```bash
    python pg.py multistyle -i idea.txt -s "Classic_Disney,Pixel_Art" \
-       -o out.png -w 4
+       --output_file out.png -w 4
    ```
    or to use randomly chosen styles:
    ```bash
-   python pg.py multistyle -i idea.txt -r 3 -o out.png
+   python pg.py multistyle -i idea.txt -r 3 --output_file out.png
    ```
    The images will be saved with timestamps and the style name in the filename.
 
@@ -66,7 +66,7 @@ API. It assumes you already have Python 3 installed and an OpenAI API key.
    If you already have a complete prompt written in a file, you can generate a
    picture without any style adaptation using `picfrompromptfile`:
    ```bash
-   python pg.py picfrompromptfile -i full_prompt.txt -o image.png
+   python pg.py picfrompromptfile -i full_prompt.txt --output_file image.png
    ```
 
 ## Configuration

--- a/pg.py
+++ b/pg.py
@@ -42,7 +42,7 @@ def cli():
 @cli.command()
 @click.option('-p', '--prompt', default=None, help='Prompt text for generating an idea.')
 @click.option('-i', '--inputfile', default=None, type=click.Path(exists=True), help='Input file with text for generating the idea.')
-@click.option('-0', '--outputfile', required=True, type=click.Path(), help='Output file to save the generated idea.')
+@click.option('-o', '--outputfile', required=True, type=click.Path(), help='Output file to save the generated idea.')
 def idea(prompt, outputfile, inputfile):
     """
     Generate an Idea


### PR DESCRIPTION
## Summary
- update docs to use `--output_file` for picture commands
- short `-o` option remains for `--outputfile` in CLI code

## Testing
- `python -m py_compile pg.py openAiMain.py support/*.py`
