### PR TITLE
Add default picture output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ examples:
   python pg.py picbystyle -i idea.txt -p "extra details" -s style1 --output_file result.png
   ```
 
+If you omit ``--output_file`` the image is saved inside ``temp/`` with a
+timestamped name like ``010124_120000_style1.png``.
+
 In short, the pipeline is:
 
 1. Generate an idea text with `pg.py idea`.

--- a/docs/CREATING_PICTURES.md
+++ b/docs/CREATING_PICTURES.md
@@ -83,6 +83,8 @@ The next sections walk through the commands that orchestrate these steps.
    python pg.py multistyle -i idea.txt -r 3 --output_file out.png
    ```
    The images will be saved with timestamps and the style name in the filename.
+   If ``--output_file`` is omitted they are written to the ``temp`` directory
+   with names like ``010124_120000_Retro_80s.png``.
 
 4. **Use an Idea File Directly**
 
@@ -91,6 +93,8 @@ The next sections walk through the commands that orchestrate these steps.
    ```bash
    python pg.py picfrompromptfile -i full_prompt.txt --output_file image.png
    ```
+   When no ``--output_file`` is specified, the picture is placed in ``temp/``
+   using a timestamped name such as ``010124_120000.png``.
 
 ## Configuration
 

--- a/pg.py
+++ b/pg.py
@@ -103,7 +103,10 @@ def multistyle(input_file, style, output_file, workers_num, random_num):
         output_file_path = sf.replace_last_path_part_with_datetime(output_adopted_prompt_file, style)
         sf.save_text_to_file(adopted_prompt, output_file_path)
         image = sf.generate_image(adopted_prompt, openAIClient, size=PIC_SIZE, quality=PIC_QUALITY)
-        output_file = sf.replace_last_path_part_with_datetime(output_file, style)
+        if output_file:
+            output_file = sf.replace_last_path_part_with_datetime(output_file, style)
+        else:
+            output_file = sf.default_output_file(style)
         sf.save_picture(output_file, image)
 
         return adopted_prompt
@@ -141,7 +144,10 @@ def picByStyle(input_file, prompt, style, output_file):
     adopted_prompt = sf.generate_adopted_prompt(additional_user_prompt, initial_idea_prompt, style, openAIClient, model_to_chat)
 
     image = sf.generate_image(adopted_prompt, openAIClient, size=PIC_SIZE, quality=PIC_QUALITY)
-    output_file = sf.replace_last_path_part_with_datetime(output_file, style)
+    if output_file:
+        output_file = sf.replace_last_path_part_with_datetime(output_file, style)
+    else:
+        output_file = sf.default_output_file(style)
     sf.save_picture(output_file, image)
     click.echo(f'Picture generated with style "{style}" based on the input prompt and saved:\n---\n{output_file}')
     ic(f"Picture saved to {output_file}")
@@ -153,7 +159,10 @@ def picByStyle(input_file, prompt, style, output_file):
 def picFromPromptFile(input_file, output_file):
     initial_idea_prompt = input_file.read()
     image = sf.generate_image(initial_idea_prompt, openAIClient, size=PIC_SIZE, quality=PIC_QUALITY)
-    output_file = sf.replace_last_path_part_with_datetime(output_file, "")
+    if output_file:
+        output_file = sf.replace_last_path_part_with_datetime(output_file, "")
+    else:
+        output_file = sf.default_output_file("")
     sf.save_picture(output_file, image)
     click.echo(f'Picture generated from file "{input_file}" based on the input prompt and saved:\n---\n{output_file}')
     ic(f"Picture saved to {output_file}")

--- a/support/functions.py
+++ b/support/functions.py
@@ -12,6 +12,7 @@ from support.logger import delog
 ADOPT_PROMPT_TXT_PATH = "temp/02_request_to_adopt_prompt.txt"
 ADOPTED_PROMPT_PATH = "temp/03_adopted_prompt.txt"
 FILE_WITH_STYLES = 'support/styles.json'
+TEMP_DIR = "temp"
 
 
 # Define the decorator
@@ -327,5 +328,32 @@ def replace_last_path_part_with_datetime(file_path, style=""):
     new_file_path = os.path.join(directory, new_file_name)
 
     return new_file_path
+
+
+def default_output_file(style: str, extension: str = ".png") -> str:
+    """Return a default output file path for a generated image.
+
+    The path points inside ``TEMP_DIR`` which will be created if it does not
+    exist. The filename is composed from the current date/time and the style
+    name using the ``ddmmyy_HHMMSS`` format, e.g. ``010124_120000_Anime.png``.
+
+    Parameters
+    ----------
+    style: str
+        Style name to include in the filename.
+    extension: str, optional
+        File extension (including the leading dot). ``.png`` by default.
+
+    Returns
+    -------
+    str
+        Full path to the default output file.
+    """
+
+    os.makedirs(TEMP_DIR, exist_ok=True)
+    current_datetime = datetime.datetime.now().strftime("%d%m%y_%H%M%S")
+    style_part = f"_{style}" if style else ""
+    file_name = f"{current_datetime}{style_part}{extension}"
+    return os.path.join(TEMP_DIR, file_name)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -52,6 +52,27 @@ class PipelineTests(unittest.TestCase):
         self.assertTrue(result.endswith("_Style_file.txt"))
         self.assertIn("2024-01-01_12-00-00", result)
 
+    def test_default_output_file(self):
+        fixed_dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+        class DummyDateTime(datetime.datetime):
+            @classmethod
+            def now(cls):
+                return fixed_dt
+
+        orig = f.datetime.datetime
+        f.datetime.datetime = DummyDateTime
+        try:
+            import tempfile
+            import os
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with mock.patch.object(f, "TEMP_DIR", tmpdir):
+                    result = f.default_output_file("Style")
+                    expected = os.path.join(tmpdir, "010124_120000_Style.png")
+                    self.assertEqual(result, expected)
+        finally:
+            f.datetime.datetime = orig
+
     def test_generate_and_save_idea(self):
         calls = {}
 


### PR DESCRIPTION
## Summary
- add a helper for producing a default output picture name
- write pictures to `temp` when no --output_file is given
- document the new behaviour in README and docs
- test the helper function

## Testing
- `python -m unittest discover -v -s tests`