### PR TITLE
Add CLI command for listing styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ examples:
   ```bash
   python pg.py addstyle -n test -d "this is a test style description" -p "orange, blue"
   ```
+- Show available styles
+  ```bash
+  python pg.py showstyles
+  ```
 
 If you omit ``--output_file`` the image is saved inside ``temp/`` with a
 timestamped name like ``010124_120000_style1.png``.

--- a/docs/CREATING_PICTURES.md
+++ b/docs/CREATING_PICTURES.md
@@ -86,7 +86,15 @@ The next sections walk through the commands that orchestrate these steps.
    If ``--output_file`` is omitted they are written to the ``temp`` directory
    with names like ``010124_120000_Retro_80s.png``.
 
-4. **Use an Idea File Directly**
+4. **Show Available Styles**
+
+   View all style names stored in ``support/styles.json``. Add ``-d`` to include
+   descriptions and ``-p`` to display palettes.
+   ```bash
+   python pg.py showstyles -d -p
+   ```
+
+5. **Use an Idea File Directly**
 
    If you already have a complete prompt written in a file, you can generate a
    picture without any style adaptation using `picfrompromptfile`:

--- a/docs/tests/USAGE.md
+++ b/docs/tests/USAGE.md
@@ -19,11 +19,20 @@ The tests verify each step of the pipeline:
 - adoption of styles and prompt preparation
 - image generation
 - utility helpers such as saving text or pictures
+- style listing via the ``showstyles`` command
 
 `tests/test_addstyle.py` covers the helper used by the `addstyle` command and
 checks that duplicate styles are rejected. `tests/test_decorators.py` validates
 the behaviour of the spinner and execution time decorators defined in
-`decorators.py`.
+`decorators.py`. `tests/test_showstyles.py` exercises the new ``showstyles``
+command.
+
+## Adding Your Own Tests
+
+Place new test modules inside the ``tests/`` directory. Use Python's ``unittest``
+framework and mimic the existing files for reference. After creating a test
+file, run ``python -m unittest discover -v -s tests`` to ensure everything still
+passes.
 
 To try the command manually run:
 

--- a/pg.py
+++ b/pg.py
@@ -191,6 +191,23 @@ def addstyle(name, description, palette):
         raise click.ClickException(str(exc))
     click.echo(f'Style "{name}" added to styles file.')
 
+
+@cli.command()
+@click.option('-d', '--description', 'show_desc', is_flag=True,
+              help='Display style descriptions.')
+@click.option('-p', '--palette', 'show_palette', is_flag=True,
+              help='Display palette information.')
+def showstyles(show_desc, show_palette):
+    """Print available styles."""
+    styles = sf.load_styles()
+    for name, info in styles.items():
+        click.echo(f'Style: {name}')
+        if show_desc:
+            click.echo(f'  Description: {info.get("description", "")}')
+        if show_palette:
+            click.echo(f'  Palette: {info.get("palette", "")}')
+        click.echo('')
+
 if __name__ == '__main__':
     config = Config.Config()
     model_to_chat = config.get("MAIN_MODEL")

--- a/support/functions.py
+++ b/support/functions.py
@@ -359,6 +359,12 @@ def add_style_to_file(name: str, description: str, palette: str, file_path: str 
     with open(file_path, "w", encoding="utf-8") as fh:
         json.dump(styles, fh, indent=4, ensure_ascii=False)
 
+
+def load_styles(file_path: str = FILE_WITH_STYLES) -> dict:
+    """Return all styles from ``file_path`` as a dictionary."""
+    with open(file_path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
         
     
 def default_output_file(style: str, extension: str = ".png") -> str:

--- a/tests/test_showstyles.py
+++ b/tests/test_showstyles.py
@@ -1,0 +1,84 @@
+import sys
+import types
+import json
+import tempfile
+import os
+import unittest
+from unittest import mock
+from click.testing import CliRunner
+
+# Stub external modules used in pg
+openai_stub = types.ModuleType('openai')
+openai_stub.Client = object
+openai_stub.OpenAI = lambda: types.SimpleNamespace()
+sys.modules['openai'] = openai_stub
+
+if 'requests' in sys.modules:
+    requests_stub = sys.modules['requests']
+else:
+    requests_stub = types.ModuleType('requests')
+    sys.modules['requests'] = requests_stub
+requests_stub.get = lambda url: types.SimpleNamespace(content=b'data')
+
+if 'support.logger' in sys.modules:
+    logger_stub = sys.modules['support.logger']
+else:
+    logger_stub = types.ModuleType('support.logger')
+    sys.modules['support.logger'] = logger_stub
+logger_stub.delog = lambda: (lambda f: f)
+logger_stub.Logger = lambda: None
+
+if 'support.decorators' in sys.modules:
+    decorators_stub = sys.modules['support.decorators']
+else:
+    decorators_stub = types.ModuleType('support.decorators')
+    sys.modules['support.decorators'] = decorators_stub
+
+decorators_stub.spinner_decorator = lambda f: f
+decorators_stub.execution_time_decorator = lambda f: f
+
+icecream_stub = types.ModuleType('icecream')
+icecream_stub.ic = lambda *a, **k: None
+sys.modules['icecream'] = icecream_stub
+
+urllib3_stub = types.ModuleType('urllib3')
+urllib3_stub.disable_warnings = lambda *a, **k: None
+urllib3_stub.exceptions = types.SimpleNamespace(NotOpenSSLWarning=type('x',(object,),{}))
+sys.modules['urllib3'] = urllib3_stub
+
+yaml_stub = types.ModuleType('yaml')
+yaml_stub.safe_load = lambda *a, **k: {}
+sys.modules['yaml'] = yaml_stub
+
+import pg
+
+class ShowStylesTests(unittest.TestCase):
+    def test_showstyles_lists_names(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = os.path.join(tmpdir, 'styles.json')
+            with open(style_path, 'w', encoding='utf-8') as fh:
+                json.dump({'Test': {'description': 'desc', 'palette': 'pal'}}, fh)
+            def loader(fp=style_path):
+                with open(style_path, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            with mock.patch('support.functions.load_styles', loader):
+                result = runner.invoke(pg.cli, ['showstyles'])
+            self.assertIn('Style: Test', result.output)
+
+    def test_showstyles_with_options(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            style_path = os.path.join(tmpdir, 'styles.json')
+            with open(style_path, 'w', encoding='utf-8') as fh:
+                json.dump({'Demo': {'description': 'd', 'palette': 'p'}}, fh)
+            def loader(fp=style_path):
+                with open(style_path, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            with mock.patch('support.functions.load_styles', loader):
+                result = runner.invoke(pg.cli, ['showstyles', '-d', '-p'])
+            self.assertIn('Description: d', result.output)
+            self.assertIn('Palette: p', result.output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `showstyles` command to CLI
- support `-d` and `-p` flags for descriptions and palettes
- document new command in README and docs
- explain tests in docs/tests
- provide unit tests for the new command

## Testing
- `python -m unittest discover -v -s tests`