### PR TITLE
Expand documentation for configuration and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,35 @@ In short, the pipeline is:
 More detailed instructions, including configuration and available styles, can be
 found in [docs/CREATING_PICTURES.md](docs/CREATING_PICTURES.md).
 
+## Configuration
+
+Runtime options are stored in `config.yaml`. Key settings include:
+
+- `MAIN_MODEL` – ChatGPT model used for prompt generation. Switch this to a GPT‑4 model if your
+  account allows it.
+- `ART_MODEL` – DALL·E version for images (currently `dall-e-3`).
+- `PIC_SIZE` – Desired output size such as `1024x1024` or `1792x1024`.
+- `PIC_QUALITY` – Set to `Standard` or `hd` for higher fidelity pictures.
+- `LOG_LEVEL` – Console log verbosity.
+
+Adjust these values to fit your workflow and API quota.
+
+## Extending `styles.json`
+
+The file `support/styles.json` holds all available art styles. Use `pg.py addstyle` to add one
+interactively or edit the JSON manually. A minimal entry looks like:
+
+```json
+{
+  "Comic_Book": {
+    "description": "Bold ink lines with halftone shading.",
+    "palette": "Strong primaries with black and white"
+  }
+}
+```
+
+After saving you can reference the new style with `-s Comic_Book`.
+
 ## Tests
 
 Mock-based tests covering each pipeline step live in the `tests/` folder. See

--- a/docs/CREATING_PICTURES.md
+++ b/docs/CREATING_PICTURES.md
@@ -114,12 +114,36 @@ ART_MODEL: "dall-e-3"
 PIC_SIZE: "1024x1024"
 PIC_QUALITY: "Standard"
 ```
-Adjust these values to suit your requirements.
+Adjust these values to suit your requirements. Each option has the following meaning:
+
+- **MAIN_MODEL** – the ChatGPT model used for text prompts. Replace with a GPT‑4 model string
+  if you need higher quality text generation.
+- **ART_MODEL** – the DALL·E model leveraged for image creation.
+- **PIC_SIZE** – output resolution. Valid values include `1024x1024`, `1024x1792` and `1792x1024`.
+- **PIC_QUALITY** – either `Standard` or `hd` to request higher fidelity images.
+- **LOG_LEVEL** – controls the verbosity of the application's logging.
 
 The available art styles are listed in `support/styles.json`. Each style
 contains a description and a color palette. When specifying the `--style`
 argument, use the keys from this file (for example `Classic_Disney` or
 `Anime`).
+
+### Adding Custom Styles
+
+You can extend `support/styles.json` manually or via the `addstyle` command.
+Below is a minimal manual snippet:
+
+```json
+{
+  "Comic_Book": {
+    "description": "Bold ink lines with halftone shading.",
+    "palette": "Strong primaries with black and white"
+  }
+}
+```
+
+After editing the file you can reference the new style with `-s Comic_Book` in
+any of the picture commands.
 
 ## Output Files
 

--- a/docs/tests/USAGE.md
+++ b/docs/tests/USAGE.md
@@ -34,6 +34,12 @@ framework and mimic the existing files for reference. After creating a test
 file, run ``python -m unittest discover -v -s tests`` to ensure everything still
 passes.
 
+When writing tests, stub out external modules such as ``openai`` or ``requests``
+so the suite remains offline and deterministic. The current tests illustrate how
+to replace these modules with simple objects before importing project code.
+Give your test functions descriptive names beginning with ``test_`` and keep
+assertions focused on one behaviour per test.
+
 To try the command manually run:
 
 ```bash


### PR DESCRIPTION
## Summary
- document runtime `config.yaml` options
- show how to add custom styles
- note testing guidelines about stubbing network modules

## Testing
- `python -m unittest discover -v -s tests`