### PR TITLE
Add characters CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ examples:
   ```bash
   python pg.py ill-story -i story.txt -o illustration.json -n 10
   ```
+- Extract characters from a story file
+  ```bash
+  python pg.py characters -i story.txt -o characters.json
+  ```
 
 
 If you omit ``--output_file`` the image is saved inside ``temp/`` with a

--- a/docs/tests/USAGE.md
+++ b/docs/tests/USAGE.md
@@ -24,8 +24,8 @@ The tests verify each step of the pipeline:
 `tests/test_addstyle.py` covers the helper used by the `addstyle` command and
 checks that duplicate styles are rejected. `tests/test_decorators.py` validates
 the behaviour of the spinner and execution time decorators defined in
-`support/decorators.py`. `tests/test_showstyles.py` exercises the new ``showstyles``
-command.
+`support/decorators.py`. `tests/test_showstyles.py` exercises the ``showstyles``
+command. `tests/test_characters_cli.py` verifies the ``characters`` command.
 
 ## Adding Your Own Tests
 

--- a/pg.py
+++ b/pg.py
@@ -9,6 +9,7 @@ import urllib3
 urllib3.disable_warnings(urllib3.exceptions.NotOpenSSLWarning)
 import support.functions as sf
 import concurrent.futures
+import json
 import support.logger as logger
 import support.Configurator as Config
 from support.logger import Logger, delog
@@ -212,6 +213,27 @@ def showstyles(show_desc, show_palette):
         if show_palette:
             click.echo(f'  Palette: {info.get("palette", "")}')
         click.echo('')
+
+
+@delog()
+@execution_time_decorator
+@spinner_decorator
+@cli.command('characters')
+@click.option('-i', '--input_file', type=click.File('r', encoding='utf-8'), required=True,
+              help='Input file containing the story text.')
+@click.option('-o', '--output_file', type=str, required=True,
+              help='Output JSON file to save the characters data.')
+def characters_cmd(input_file, output_file):
+    """Extract characters from a story and save them to JSON."""
+    story_text = input_file.read()
+    click.echo(f"Extracting characters from {input_file.name}...")
+    characters = sf.extract_characters(story_text, openAIClient, model_to_chat)
+    if not output_file.lower().endswith('.json'):
+        output_file += '.json'
+    with open(output_file, 'w', encoding='utf-8') as fh:
+        json.dump(characters, fh, indent=2, ensure_ascii=False)
+    sf.log_prompt_output('characters', story_text[:500] + '...' if len(story_text) > 500 else story_text, output_file)
+    click.echo(f"Characters saved to: {output_file}")
 
 
 @delog()

--- a/tests/test_characters_cli.py
+++ b/tests/test_characters_cli.py
@@ -1,0 +1,73 @@
+import sys
+import types
+import json
+import tempfile
+import os
+import unittest
+from unittest import mock
+from click.testing import CliRunner
+
+# Stub external modules used in pg
+openai_stub = types.ModuleType('openai')
+openai_stub.Client = object
+openai_stub.OpenAI = lambda: types.SimpleNamespace()
+sys.modules['openai'] = openai_stub
+
+if 'requests' in sys.modules:
+    requests_stub = sys.modules['requests']
+else:
+    requests_stub = types.ModuleType('requests')
+    sys.modules['requests'] = requests_stub
+requests_stub.get = lambda url: types.SimpleNamespace(content=b'data')
+
+if 'support.logger' in sys.modules:
+    logger_stub = sys.modules['support.logger']
+else:
+    logger_stub = types.ModuleType('support.logger')
+    sys.modules['support.logger'] = logger_stub
+logger_stub.delog = lambda: (lambda f: f)
+logger_stub.Logger = lambda: None
+
+if 'support.decorators' in sys.modules:
+    decorators_stub = sys.modules['support.decorators']
+else:
+    decorators_stub = types.ModuleType('support.decorators')
+    sys.modules['support.decorators'] = decorators_stub
+
+decorators_stub.spinner_decorator = lambda f: f
+decorators_stub.execution_time_decorator = lambda f: f
+
+icecream_stub = types.ModuleType('icecream')
+icecream_stub.ic = lambda *a, **k: None
+sys.modules['icecream'] = icecream_stub
+
+urllib3_stub = types.ModuleType('urllib3')
+urllib3_stub.disable_warnings = lambda *a, **k: None
+urllib3_stub.exceptions = types.SimpleNamespace(NotOpenSSLWarning=type('x',(object,),{}))
+sys.modules['urllib3'] = urllib3_stub
+
+yaml_stub = types.ModuleType('yaml')
+yaml_stub.safe_load = lambda *a, **k: {}
+sys.modules['yaml'] = yaml_stub
+
+import pg
+
+class CharactersCliTests(unittest.TestCase):
+    def test_characters_command_writes_file(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = os.path.join(tmpdir, 'story.txt')
+            output_path = os.path.join(tmpdir, 'chars.json')
+            with open(input_path, 'w', encoding='utf-8') as fh:
+                fh.write('Once upon a time')
+            sample = {'Hero': {'info': 'x'}}
+            with mock.patch('support.functions.extract_characters', return_value=sample):
+                pg.model_to_chat = 'test-model'
+                result = runner.invoke(pg.cli, ['characters', '-i', input_path, '-o', output_path])
+            self.assertEqual(result.exit_code, 0)
+            with open(output_path, 'r', encoding='utf-8') as fh:
+                data = json.load(fh)
+            self.assertEqual(data, sample)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `characters` command to CLI for extracting character information
- document the command in the README
- mention new test module in documentation
- provide unit tests for the new command

## Testing
- `python -m unittest discover -v -s tests`