### PR TITLE
Add charfile option to ill-story command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ examples:
 - Illustrate a story by generating character descriptions and scene breakdowns
   ```bash
   python pg.py ill-story -i story.txt -o illustration.json -n 10
+  # reuse existing characters
+  python pg.py ill-story -i story.txt -o illustration.json -n 10 -c chars.json
   ```
 
 

--- a/docs/ILLUSTRATING_STORIES.md
+++ b/docs/ILLUSTRATING_STORIES.md
@@ -1,0 +1,31 @@
+# Illustrating Stories
+
+This guide explains how to use the `ill-story` command to generate
+character descriptions and scene breakdowns from a text file.
+
+The command reads a story, identifies characters, and produces a JSON
+structure describing each key scene. Optionally, you can provide a JSON
+file with pre-generated characters using the `--charfile` option.
+
+## Basic Usage
+
+```bash
+python pg.py ill-story -i story.txt -o illustration.json -n 8
+```
+
+The resulting `illustration.json` contains the story summary, characters,
+and scenes. Each scene includes information about the setting, objects and
+which characters appear.
+
+## Reusing Character Descriptions
+
+If you already have character descriptions saved in a file, pass it with
+`-c` or `--charfile` to skip character generation:
+
+```bash
+python pg.py ill-story -i story.txt -o illustration.json -n 8 -c characters.json
+```
+
+The JSON must map character names to the structure returned by the
+`CharacterDescription` model. If the file cannot be parsed or does not
+match the expected schema the command stops with an error message.

--- a/pg.py
+++ b/pg.py
@@ -1,15 +1,13 @@
 import click
 from openai import OpenAI
 from icecream import ic
-from support import functions as sf
+import support.functions as sf
 # Decorators used across CLI commands
 from support.decorators import spinner_decorator, execution_time_decorator
 # from support.functions import generate_image, save_picture, get_dalle_prompt_based_on_input, execution_time_decorator, save_text_to_file
 import urllib3
 urllib3.disable_warnings(urllib3.exceptions.NotOpenSSLWarning)
-import support.functions as sf
 import concurrent.futures
-import support.logger as logger
 import support.Configurator as Config
 from support.logger import Logger, delog
 
@@ -220,11 +218,14 @@ def showstyles(show_desc, show_palette):
 @cli.command()
 @click.option('-i', '--input_file', type=click.File('r', encoding="utf-8"), required=True,
               help='Input file containing the story text.')
-@click.option('-o', '--output_file', type=str, required=True, 
+@click.option('-o', '--output_file', type=str, required=True,
               help='Output JSON file to save the illustration data.')
-@click.option('-n', '--num_scenes', type=int, default=10, 
+@click.option('-n', '--num_scenes', type=int, default=10,
               help='Number of scenes to generate (default: 10).')
-def ill_story(input_file, output_file, num_scenes):
+@click.option('-c', '--charfile', type=click.Path(exists=True, dir_okay=False),
+              default=None,
+              help='Optional JSON file with character descriptions.')
+def ill_story(input_file, output_file, num_scenes, charfile):
     """
     Illustrate a story by generating character descriptions and scene breakdowns.
 
@@ -240,6 +241,9 @@ def ill_story(input_file, output_file, num_scenes):
         Path to save the output JSON file.
     num_scenes : int, optional
         Number of scenes to generate (default: 10).
+    charfile : str, optional
+        JSON file with pre-generated character descriptions. If provided,
+        characters are loaded from this file instead of being generated.
 
     Returns:
     --------
@@ -248,6 +252,7 @@ def ill_story(input_file, output_file, num_scenes):
     Example usage:
     -------------
     pg.py ill_story --input_file story.txt --output_file illustration.json --num_scenes 12
+    pg.py ill_story -i story.txt -o illustration.json -n 10 -c characters.json
     """
     # Read the story text from the input file
     story_text = input_file.read()
@@ -256,7 +261,11 @@ def ill_story(input_file, output_file, num_scenes):
 
 
     # Log the command execution
-    click.echo(f"Illustrating story from {input_file.name} with {num_scenes} scenes...")
+    msg = f"Illustrating story from {input_file.name} with {num_scenes} scenes"
+    if charfile:
+        msg += f" using characters from {charfile}"
+    msg += "..."
+    click.echo(msg)
 
     # Ensure output file has .json extension
     if not output_file.lower().endswith('.json'):
@@ -268,7 +277,8 @@ def ill_story(input_file, output_file, num_scenes):
         output_file=output_file,
         num_scenes=num_scenes,
         openai_client=openAIClient,
-        model=model_to_chat
+        model=model_to_chat,
+        charfile=charfile
     )
 
     # Check if the operation was successful


### PR DESCRIPTION
## Summary
- allow `ill-story` to load characters from a JSON file
- validate the provided file with `load_characters_from_file`
- add `--charfile` option to CLI and improve logging
- document the new feature and include new doc file
- test character file behaviour
- clean duplicate imports

## Testing
- `python -m unittest discover -v -s tests`
