### PR TITLE
Add setup and test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ styles.
    git clone <repo-url>
    cd pigen
    ```
-2. Install dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
+2. Set up a Python virtual environment and install dependencies using the
+   provided helper scripts. Choose the script matching your platform:
+   - **Linux/macOS**
+     ```bash
+     ./scripts/install_linux.sh
+     ```
+   - **Windows**
+     ```powershell
+     powershell -ExecutionPolicy Bypass -File scripts/install_windows.ps1
+     ```
 3. Set your `OPENAI_API_KEY` environment variable. In a Unix shell use
    `export OPENAI_API_KEY=<your-key>`.
 
@@ -103,7 +109,19 @@ After saving you can reference the new style with `-s Comic_Book`.
 
 ## Tests
 
-Mock-based tests covering each pipeline step live in the `tests/` folder. See
-[docs/tests/USAGE.md](docs/tests/USAGE.md) for instructions on running them.
-The `test_addstyle.py` module ensures the `addstyle` command works as expected
-and demonstrates how to add and remove a sample style entry.
+Mock-based tests covering each pipeline step live in the `tests/` folder. Use
+the helper scripts to run them after setting up your environment:
+
+- **Linux/macOS**
+  ```bash
+  ./scripts/run_tests.sh
+  ```
+- **Windows**
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1
+  ```
+
+More details can be found in
+[docs/tests/USAGE.md](docs/tests/USAGE.md). The `test_addstyle.py` module
+ensures the `addstyle` command works as expected and demonstrates how to add and
+remove a sample style entry.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,40 @@
+# Installation Guide
+
+This document explains how to set up the `pigen` project using the provided
+helper scripts. The scripts create a Python virtual environment and install all
+required packages listed in `requirements.txt`.
+
+## Linux/macOS
+
+Run the shell script from the repository root:
+
+```bash
+./scripts/install_linux.sh
+```
+
+This creates a `venv` folder and installs the dependencies inside it.
+
+## Windows
+
+Execute the PowerShell script in a terminal with sufficient privileges:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/install_windows.ps1
+```
+
+A `venv` directory is created and all requirements are installed.
+
+## Running the Tests
+
+After installation you can run the offline test suite.
+
+- **Linux/macOS**
+  ```bash
+  ./scripts/run_tests.sh
+  ```
+- **Windows**
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1
+  ```
+
+The scripts ensure all packages are available before executing the tests.

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# install_linux.sh - Set up Python virtual environment and install dependencies
+# for the pigen project on Linux.
+#
+# This script creates a virtual environment in the "venv" directory and
+# installs all packages listed in requirements.txt.
+#
+# Usage: ./scripts/install_linux.sh
+
+set -e
+
+echo "[pigen] Creating Python virtual environment..."
+
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+    echo "[pigen] Virtual environment created."
+else
+    echo "[pigen] Virtual environment already exists."
+fi
+
+# Activate the environment
+source venv/bin/activate
+
+echo "[pigen] Installing dependencies from requirements.txt..."
+pip install -r requirements.txt
+
+echo "[pigen] Environment setup complete."

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,0 +1,25 @@
+<##
+    install_windows.ps1 - Setup Python virtual environment and install dependencies
+    for the pigen project on Windows using PowerShell.
+
+    Usage: powershell -ExecutionPolicy Bypass -File scripts/install_windows.ps1
+##>
+
+$ErrorActionPreference = 'Stop'
+
+Write-Output "[pigen] Creating Python virtual environment..."
+
+if (-Not (Test-Path 'venv')) {
+    python -m venv venv
+    Write-Output "[pigen] Virtual environment created."
+} else {
+    Write-Output "[pigen] Virtual environment already exists."
+}
+
+# Activate the environment for the current script scope
+& .\venv\Scripts\Activate.ps1
+
+Write-Output "[pigen] Installing dependencies from requirements.txt..."
+pip install -r requirements.txt
+
+Write-Output "[pigen] Environment setup complete."

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -1,0 +1,33 @@
+<##
+    run_tests.ps1 - Execute the unit test suite for the pigen project on Windows.
+    If required packages are missing the installation script is invoked.
+
+    Usage: powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1
+##>
+
+$ErrorActionPreference = 'Stop'
+
+if (-Not (Test-Path 'venv')) {
+    Write-Output "[pigen] Virtual environment not found. Running installer..."
+    .\scripts\install_windows.ps1
+}
+
+& .\venv\Scripts\Activate.ps1
+
+$requirements = Get-Content requirements.txt
+$missing = $false
+foreach ($pkg in $requirements) {
+    if (-not (pip show $pkg | Out-Null)) {
+        $missing = $true
+    }
+}
+
+if ($missing) {
+    Write-Output "[pigen] Installing missing packages..."
+    pip install -r requirements.txt
+} else {
+    Write-Output "[pigen] All requirements already satisfied."
+}
+
+Write-Output "[pigen] Running unit tests..."
+python -m unittest discover -v -s tests

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# run_tests.sh - Execute the unit test suite for the pigen project on Linux.
+# If the required packages are missing the installation script is invoked.
+#
+# Usage: ./scripts/run_tests.sh
+
+set -e
+
+# Ensure dependencies are installed
+missing=false
+if [ ! -d "venv" ]; then
+    echo "[pigen] Virtual environment not found. Running installer..."
+    ./scripts/install_linux.sh
+fi
+
+source venv/bin/activate
+
+for pkg in $(cut -d'=' -f1 requirements.txt); do
+    pip show "$pkg" >/dev/null 2>&1 || missing=true
+done
+
+if [ "$missing" = true ]; then
+    echo "[pigen] Installing missing packages..."
+    pip install -r requirements.txt
+else
+    echo "[pigen] All requirements already satisfied."
+fi
+
+echo "[pigen] Running unit tests..."
+python -m unittest discover -v -s tests


### PR DESCRIPTION
## Summary
- add setup scripts for Linux and Windows
- add scripts to run tests on both platforms
- document scripts in README and new INSTALLATION guide

## Testing
- `python -m unittest discover -v -s tests`