### PR TITLE
Add preflight check utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ styles.
      ```
 3. Set your `OPENAI_API_KEY` environment variable. In a Unix shell use
    `export OPENAI_API_KEY=<your-key>`.
+4. (Optional) Run the preflight check to verify your installation:
+   - **Linux/macOS**
+     ```bash
+     ./scripts/preflight.sh
+     ```
+   - **Windows**
+     ```powershell
+     powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
+     ```
+   The check runs automatically whenever `pg.py` starts but the scripts allow
+   you to test your setup manually.
 
 ## Quick Usage
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -24,6 +24,21 @@ powershell -ExecutionPolicy Bypass -File scripts/install_windows.ps1
 
 A `venv` directory is created and all requirements are installed.
 
+## Preflight Check
+
+Run the preflight script to verify that dependencies and environment variables
+are correctly configured.
+
+- **Linux/macOS**
+  ```bash
+  ./scripts/preflight.sh
+  ```
+- **Windows**
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
+  ```
+This step is optional because `pg.py` executes the same validation on startup.
+
 ## Running the Tests
 
 After installation you can run the offline test suite.

--- a/pg.py
+++ b/pg.py
@@ -20,8 +20,12 @@ import json
 import support.logger as logger
 import support.Configurator as Config
 from support.logger import Logger, delog
+from support.preflight import preflight_check
+
 
 logger = Logger()
+# Ensure environment is ready before continuing
+preflight_check()
 
 
 openAIClient = OpenAI()

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -1,0 +1,2 @@
+# Preflight check for pigen on Windows
+python support/preflight.py

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Preflight check for pigen on Linux/macOS
+python support/preflight.py

--- a/support/preflight.py
+++ b/support/preflight.py
@@ -1,0 +1,65 @@
+import os
+import pkg_resources
+from typing import Iterable, List, Optional
+
+
+def _load_requirements(requirements_file: str) -> List[str]:
+    reqs: List[str] = []
+    with open(requirements_file, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith('#'):
+                reqs.append(line)
+    return reqs
+
+
+def preflight_check(env_vars: Optional[Iterable[str]] = None,
+                    requirements: Optional[Iterable[str]] = None,
+                    requirements_file: str = 'requirements.txt') -> bool:
+    """Verify environment variables and installed packages.
+
+    Parameters
+    ----------
+    env_vars : Iterable[str], optional
+        Names of required environment variables. Defaults to ['OPENAI_API_KEY'].
+    requirements : Iterable[str], optional
+        Explicit package requirement strings. If omitted, ``requirements_file``
+        is read.
+    requirements_file : str
+        Path to the requirements file.
+
+    Returns
+    -------
+    bool
+        True if all checks pass.
+
+    Raises
+    ------
+    EnvironmentError
+        If an environment variable is missing.
+    ImportError
+        If a package is not installed or version conflicts.
+    """
+    env_vars = list(env_vars) if env_vars is not None else ['OPENAI_API_KEY']
+    missing_env = [var for var in env_vars if not os.getenv(var)]
+    if missing_env:
+        raise EnvironmentError(f"Missing environment variables: {', '.join(missing_env)}")
+
+    if requirements is None:
+        requirements = _load_requirements(requirements_file)
+
+    try:
+        pkg_resources.require(list(requirements))
+    except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict) as exc:
+        raise ImportError(str(exc)) from exc
+
+    return True
+
+
+if __name__ == '__main__':
+    try:
+        preflight_check()
+        print('[pigen] Preflight check successful.')
+    except Exception as exc:  # pragma: no cover - direct script execution
+        print(f'[pigen] Preflight check failed: {exc}')
+        raise

--- a/tests/test_characters_cli.py
+++ b/tests/test_characters_cli.py
@@ -55,6 +55,7 @@ yaml_stub = types.ModuleType('yaml')
 yaml_stub.safe_load = lambda *a, **k: {}
 sys.modules['yaml'] = yaml_stub
 
+os.environ['OPENAI_API_KEY'] = 'test'
 import pg
 
 class CharactersCliTests(unittest.TestCase):

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+from unittest import mock
+import pkg_resources
+
+from support import preflight
+
+
+class PreflightTests(unittest.TestCase):
+    def test_missing_env_raises(self):
+        with self.assertRaises(EnvironmentError):
+            preflight.preflight_check(env_vars=['MISSING'], requirements=[])
+
+    def test_missing_package_raises(self):
+        os.environ['OPENAI_API_KEY'] = 'x'
+        with mock.patch('pkg_resources.require', side_effect=pkg_resources.DistributionNotFound('demo')):
+            with self.assertRaises(ImportError):
+                preflight.preflight_check(env_vars=['OPENAI_API_KEY'], requirements=['demo'])
+
+    def test_success(self):
+        os.environ['OPENAI_API_KEY'] = 'x'
+        with mock.patch('pkg_resources.require', return_value=None) as req:
+            result = preflight.preflight_check(env_vars=['OPENAI_API_KEY'], requirements=['demo'])
+        self.assertTrue(result)
+        req.assert_called_once_with(['demo'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_showstyles.py
+++ b/tests/test_showstyles.py
@@ -55,6 +55,7 @@ yaml_stub = types.ModuleType('yaml')
 yaml_stub.safe_load = lambda *a, **k: {}
 sys.modules['yaml'] = yaml_stub
 
+os.environ['OPENAI_API_KEY'] = 'test'
 import pg
 
 class ShowStylesTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add small preflight module that checks env vars and required packages
- add bash and PowerShell scripts that run the check
- call `preflight_check()` at start of `pg.py`
- document how to run the new script
- adjust tests and add coverage for preflight

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install requirements)*