### PR TITLE
Improve documentation structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to pigen
+
+Thank you for considering contributing to this project. Please follow the steps below to submit changes:
+
+1. Fork the repository and create your feature branch.
+2. Install the requirements using the provided scripts in `scripts/`.
+3. Run the test suite with `./scripts/run_tests.sh` to ensure all tests pass.
+4. Make your changes with clear, descriptive commit messages.
+5. Submit a pull request and describe your changes in detail.
+
+For more information on the project structure see [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,52 @@
 # pigen
 
-## TL;DR
-Generate image prompts and pictures with OpenAI's DALL·E API using a simple
-command-line tool.
+![CI](https://img.shields.io/github/actions/workflow/status/example/pigen/test.yml?label=CI)
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
 
-Utilities for generating images with OpenAI's DALL·E API. The project provides a
-CLI (`pg.py`) that helps you craft prompts and render pictures in various
-styles.
+Generate image prompts and pictures with OpenAI's DALL\u00b7E API using a simple command-line tool.
+
+Utilities for crafting prompts, applying art styles and rendering images. The CLI `pg.py` also helps with story illustration workflows.
+
+## Table of Contents
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Quick Usage](#quick-usage)
+- [Configuration](#configuration)
+- [Extending styles](#extending-stylesjson)
+- [Running Tests](#running-tests)
+- [Contributing](#contributing)
+- [License](#license)
+- [Documentation](#documentation)
+
+## Features
+- Generate idea prompts using ChatGPT
+- Adapt prompts to predefined art styles
+- Create single or multiple styled images
+- Manage style definitions in `styles.json`
+- Illustrate stories by generating scenes and characters
+
+## Prerequisites
+- Python 3.11+
+- An OpenAI API key stored in the `OPENAI_API_KEY` environment variable
 
 ## Installation
-
 1. Clone the repository and enter its folder:
    ```bash
    git clone <repo-url>
    cd pigen
    ```
-2. Set up a Python virtual environment and install dependencies using the
-   provided helper scripts. Choose the script matching your platform:
+2. Set up a Python virtual environment and install dependencies using the provided helper scripts. Choose the script matching your platform:
    - **Linux/macOS**
      ```bash
      ./scripts/install_linux.sh
      ```
    - **Windows**
      ```powershell
-    powershell -ExecutionPolicy Bypass -File scripts/install_windows.ps1
-    ```
-   The scripts install all requirements, including the optional OpenTelemetry
-   packages used for tracing support.
-3. Set your `OPENAI_API_KEY` environment variable. In a Unix shell use
-   `export OPENAI_API_KEY=<your-key>`.
+     powershell -ExecutionPolicy Bypass -File scripts/install_windows.ps1
+     ```
+   The scripts install all requirements, including the optional OpenTelemetry packages used for tracing support.
+3. Set your `OPENAI_API_KEY` environment variable. In a Unix shell use `export OPENAI_API_KEY=<your-key>`.
 4. (Optional) Run the preflight check to verify your installation:
    - **Linux/macOS**
      ```bash
@@ -38,14 +56,10 @@ styles.
      ```powershell
      powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
      ```
-   The check runs automatically whenever `pg.py` starts but the scripts allow
-   you to test your setup manually.
+   The check runs automatically whenever `pg.py` starts but the scripts allow you to test your setup manually.
 
 ## Quick Usage
-
-The CLI supports several commands for working with prompts and pictures. A few
-examples:
-
+The CLI supports several commands for working with prompts and pictures. A few examples:
 - Generate an idea prompt and save it to a file
   ```bash
   python pg.py idea --prompt "Generate a new project idea" --outputfile idea.txt
@@ -77,27 +91,21 @@ examples:
   python pg.py characters -i story.txt -o characters.json
   ```
 
-
-If you omit ``--output_file`` the image is saved inside ``temp/`` with a
-timestamped name like ``010124_120000_style1.png``.
+If you omit `--output_file` the image is saved inside `temp/` with a timestamped name like `010124_120000_style1.png`.
 
 In short, the pipeline is:
-
 1. Generate an idea text with `pg.py idea`.
 2. Apply one or more styles using `picbystyle` or `multistyle`.
-3. The final prompt is sent to DALL·E and the image is saved with a timestamp.
+3. The final prompt is sent to DALL\u00b7E and the image is saved with a timestamp.
 
 More detailed instructions can be found in:
 - [Creating Pictures](docs/CREATING_PICTURES.md) - How to generate images with styles
 - [Illustrating Stories](docs/ILLUSTRATING_STORIES.md) - How to analyze stories for illustration
 
 ## Configuration
-
 Runtime options are stored in `config.yaml`. Key settings include:
-
-- `MAIN_MODEL` – ChatGPT model used for prompt generation. Switch this to a GPT‑4 model if your
-  account allows it.
-- `ART_MODEL` – DALL·E version for images (currently `dall-e-3`).
+- `MAIN_MODEL` – ChatGPT model used for prompt generation. Switch this to a GPT‑4 model if your account allows it.
+- `ART_MODEL` – DALL\u00b7E version for images (currently `dall-e-3`).
 - `PIC_SIZE` – Desired output size such as `1024x1024` or `1792x1024`.
 - `PIC_QUALITY` – Set to `Standard` or `hd` for higher fidelity pictures.
 - `LOG_LEVEL` – Console log verbosity.
@@ -107,11 +115,8 @@ Runtime options are stored in `config.yaml`. Key settings include:
 
 Adjust these values to fit your workflow and API quota.
 
-## Extending `styles.json`
-
-The file `support/styles.json` holds all available art styles. Use `pg.py addstyle` to add one
-interactively or edit the JSON manually. A minimal entry looks like:
-
+## Extending styles.json
+The file `support/styles.json` holds all available art styles. Use `pg.py addstyle` to add one interactively or edit the JSON manually. A minimal entry looks like:
 ```json
 {
   "Comic_Book": {
@@ -120,14 +125,10 @@ interactively or edit the JSON manually. A minimal entry looks like:
   }
 }
 ```
-
 After saving you can reference the new style with `-s Comic_Book`.
 
-## Tests
-
-Mock-based tests covering each pipeline step live in the `tests/` folder. Use
-the helper scripts to run them after setting up your environment:
-
+## Running Tests
+Mock-based tests covering each pipeline step live in the `tests/` folder. Use the helper scripts to run them after setting up your environment:
 - **Linux/macOS**
   ```bash
   ./scripts/run_tests.sh
@@ -136,12 +137,20 @@ the helper scripts to run them after setting up your environment:
   ```powershell
   powershell -ExecutionPolicy Bypass -File scripts/run_tests.ps1
   ```
+More details can be found in [docs/tests/USAGE.md](docs/tests/USAGE.md).
 
-More details can be found in
-[docs/tests/USAGE.md](docs/tests/USAGE.md). The `test_addstyle.py` module
-ensures the `addstyle` command works as expected and demonstrates how to add and
-remove a sample style entry.
+## Contributing
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to submit patches and feature requests.
 
-For instructions on configuring logging, running the CLI and executing
-individual tests see
-[docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md).
+## License
+This project is licensed under the [MIT License](LICENSE).
+
+## Documentation
+| File | Description |
+|------|-------------|
+| [docs/CREATING_PICTURES.md](docs/CREATING_PICTURES.md) | Step-by-step guide for generating images with different styles |
+| [docs/ILLUSTRATING_STORIES.md](docs/ILLUSTRATING_STORIES.md) | Explain how to break down a story into scenes and characters |
+| [docs/INSTALLATION.md](docs/INSTALLATION.md) | Alternative installation instructions for all platforms |
+| [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md) | Details on configuration, logging and test execution |
+| [docs/tests/USAGE.md](docs/tests/USAGE.md) | Instructions for running the unit tests directly |
+


### PR DESCRIPTION
## Summary
- restructure README with features, prerequisites and docs table
- add MIT license
- provide basic CONTRIBUTING guide

## Testing
- `python -m unittest discover -v -s tests`
- `ruff check .` *(fails: F401, F403, E402 and other issues)*